### PR TITLE
Updating development environment setup guide

### DIFF
--- a/source/developers/development_environment.markdown
+++ b/source/developers/development_environment.markdown
@@ -11,20 +11,55 @@ footer: true
 
 You'll need to set up a development environment if you want to develop a new feature or component for Home Assistant. Read on to learn how to set up.
 
-* Visit the [Home Assistant repository](https://github.com/home-assistant/home-assistant) and click **Fork**.
+### {% linkable_title Setup Local Repository %}
 
-* Consider setting up a virtual environment using [`venv`](https://docs.python.org/3.4/library/venv.html) before running the setup script.
-
+Visit the [Home Assistant repository](https://github.com/home-assistant/home-assistant) and click **Fork**.
+Once forked, setup your local copy of the source using the commands:
 ```bash
 $ git clone https://github.com/YOUR_GIT_USERNAME/home-assistant.git
 $ cd home-assistant
 $ git remote add upstream https://github.com/home-assistant/home-assistant.git
+```
+
+### {% linkable_title Prepare Your Environment %}
+
+#### {% linkable_title Core dependencies %} 
+
+Install the core dependencies.
+```bash
+$ sudo apt-get install python3-pip python3-dev libssl-dev
+```
+
+#### {% linkable_title Frontend dependencies (optional) %} 
+
+In order to run or develop the [Frontend](https://home-assistant.io/developers/frontend/) you will need node.js. The preferred method of installing node is [nvm](https://github.com/creationix/nvm). Install nvm using the instructions in the [README](https://github.com/creationix/nvm#install-script), and install node.js by running the following command:
+```bash
+$ nvm install node
+```
+
+#### {% linkable_title Setting up virtual environment (optional) %} 
+
+If you plan on providing isolation to your environment using [`venv`](https://docs.python.org/3.4/library/venv.html). You'll need to install the python3-venv package:
+```bash
+$ sudo apt-get install python3-venv
+```
+Within the `home-assistant` directory, create and activate your virtual environment using the commands:
+```bash
+$ pyvenv venv
+$ source venv/bin/activate
+```
+
+### {% linkable_title Setup and Run %}
+
+* On Mac OS X and Linux 
+```bash
+$ cd home-assistant
 $ script/setup
 ```
 
 * On Windows, you can use `python setup.py develop` instead of the setup script.
 
-* Run `hass` to invoke your local installation.
+* Run `hass` to invoke your local installation of the backend server or `hass --open-ui` to start the server and serve the web interface on http://localhost:8123
 
 ### {% linkable_title Logging %}
 


### PR DESCRIPTION
**Description:**
Added more complete instructions for setting up a development environment for Home Assistant. Including details of dependencies, setting up venv. This is based on notes captured from setting up a dedicated hass dev environment on Debian 8.6.0